### PR TITLE
Suggest FontProof workflow

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,9 +4,14 @@
 # More details in the GitLab documentation at https://docs.gitlab.com/ce/ci/README.html
 # Enjoy and let us know if you find issues. 
 
-image: "ubuntu:focal"
+default:
+  image: "ubuntu:focal"
 
-build:
+stages:
+  - build
+  - test
+
+smith:
   stage: build
   before_script:
     - apt-get update -q -y
@@ -18,8 +23,6 @@ build:
     - apt-get install sile python-odf python-odf-tools libjson-perl libtext-csv-perl libharfbuzz-bin -y
     - apt-get install smith-font -y --no-install-recommends
     - python3 -m pip install --upgrade git+https://github.com/googlefonts/fontbakery.git@main#egg=fontbakery 
-
-
   script:
     - smith configure
     - smith build
@@ -28,7 +31,6 @@ build:
     - smith zip
     - smith tarball
     - smith release 
-
   artifacts:
     name: "${CI_PROJECT_NAME}-${CI_COMMIT_REF_NAME}${CI_COMMIT_SHA:0:8}-build${CI_JOB_ID}"
     paths:
@@ -38,3 +40,19 @@ build:
     - results/*.txt
     - results/*err*
     - results/tests/*
+
+fontproof:
+  stage: test
+  image:
+    name: ghcr.io/sile-typesetter/fontpfoof:v2
+    entrypoint: [""] # default entrypoint is fontproof itself, not a shell
+  needs:
+    - job: smith
+  script:
+    - |
+      for ttf in results/*.ttf; do
+        fontproof -f $ttf -o FontProof-$(basename ${ttf%.ttf}).pdf -- tests/Latin.sil
+      done
+  artifacts:
+    paths:
+      - FontProof-*.pdf

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,18 +11,23 @@ stages:
   - build
   - test
 
+variables:
+  DEBIAN_FRONTEND: noninteractive
+  TZ: Etc/UTC
+
 smith:
   stage: build
   before_script:
     - apt-get update -q -y
-    - apt-get install -q -y software-properties-common libterm-readline-gnu-perl
-    - add-apt-repository -y ppa:silnrsi/smith
+    - apt-get install -q -y tzdata software-properties-common libterm-readline-gnu-perl python3-pip
+    - add-apt-repository -y ppa:silnrsi/smith-py3
     - add-apt-repository -y ppa:git-core/ppa
     - add-apt-repository -y ppa:sile-typesetter/sile
-    - apt-get update -q -y 
-    - apt-get install sile python-odf python-odf-tools libjson-perl libtext-csv-perl libharfbuzz-bin -y
-    - apt-get install smith-font -y --no-install-recommends
-    - python3 -m pip install --upgrade git+https://github.com/googlefonts/fontbakery.git@main#egg=fontbakery 
+    - apt-get update -q -y
+    - apt-get install -q -y sile python3-odf python-odf-tools libjson-perl libtext-csv-perl libharfbuzz-bin
+    - apt-get install -q -y --no-install-recommends smith-font
+    - pip install fontbakery
+    - git config --global safe.directory $PWD
   script:
     - smith configure
     - smith build


### PR DESCRIPTION
This is an attempt to suggest a workflow using FontProof.

Obviously there are several ways to skin this cat. I'll probably get `fontproof` added to the SILE PPA so it will be installable with apt-get, but I haven't done that yet. In the mean time it could be installed with `luarocks install` into the runner along side the other dependencies in `before_sript`.

However I think all of this is *way too complicated*. The build time for taking a plain Ubuntu image and just updating it even to the point of being able to install more dependencies into the runner is huge, and it doesn't cache.

I suggest making a Docker image for `smith` that has all the dependencies already and can just be spun up by a CI runner instead of having to bring the whole base image up to date on every run. In addition it would be a lot easier to *version* because CI runners could request a tagged container that will come with matching versions of everything.

This would be a sample of how that could work since FontProof already has a docker image. Here we're running whatever the latest is in the v2 series, at the moment that's the same as v2.0.0. The `smith` job could be refactored to run a similar image for smith, and ditch the entire `before_script` part, speeding 10+ minutes up to a few seconds of run time.
